### PR TITLE
Change constant for trigger_error

### DIFF
--- a/3.3/Pubnub.php
+++ b/3.3/Pubnub.php
@@ -277,7 +277,7 @@ class Pubnub
     public function handleError($error, $args)
     {
         $errorMsg = 'Error on line ' . $error->getLine() . ' in ' . $error->getFile() . $error->getMessage();
-        trigger_error($errorMsg, E_COMPILE_WARNING);
+        trigger_error($errorMsg, E_USER_WARNING);
 
 
         sleep(1);


### PR DESCRIPTION
According to http://php.net/manual/en/function.trigger-error.php

```
error_type
The designated error type for this error. It only works with the E_USER family of constants, and will default to E_USER_NOTICE.
```

So to discover what is happening in exceptions I've only change to E_USER family for compliance.
